### PR TITLE
修复因为OmetaT默认大写LanguageCode导致腾讯云API报错

### DIFF
--- a/src/main/java/indi/yoyicue/machinetranslators/TencentTranslate.java
+++ b/src/main/java/indi/yoyicue/machinetranslators/TencentTranslate.java
@@ -85,7 +85,7 @@ public class TencentTranslate extends BaseTranslate {
         } else if (lang.equalsIgnoreCase("ko")) {
             return "kr";
         } else {
-            return language.getLanguageCode();
+            return language.getLanguageCode().toLowerCase();
         }
 
     }


### PR DESCRIPTION
1)修复因为OmetaT默认大写LanguageCode导致腾讯云API报错。

在Country不符合 https://cloud.tencent.com/document/product/551/7380 中提到的“支持语言列表”（区分大小写），导致API返回“服务内部错误，请稍后重试或联系客服人员解决。”的问题。